### PR TITLE
Upgrade fix version; move react-hot-loader to dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cooking-with-amateurs",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cooking-with-amateurs",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.1.0",
@@ -22,6 +22,7 @@
         "mongoose": "^5.9.7",
         "react": "^16.13.1",
         "react-dom": "^16.8.0",
+        "react-hot-loader": "^4.12.19",
         "react-router-dom": "^5.1.2",
         "ts-loader": "^7.0.2",
         "webpack": "^5.56.1",
@@ -53,7 +54,6 @@
         "nodemon": "^2.0.13",
         "prettier": "^1.19.1",
         "pretty-quick": "^2.0.1",
-        "react-hot-loader": "^4.12.19",
         "typescript": "^3.8.3",
         "webpack-dev-server": "^4.3.1"
       },
@@ -17463,7 +17463,6 @@
       "version": "4.12.19",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.19.tgz",
       "integrity": "sha512-p8AnA4QE2GtrvkdmqnKrEiijtVlqdTIDCHZOwItkI9kW51bt5XnQ/4Anz8giiWf9kqBpEQwsmnChDCAFBRyR/Q==",
-      "dev": true,
       "dependencies": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -17487,7 +17486,6 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -35277,7 +35275,6 @@
       "version": "4.12.19",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.19.tgz",
       "integrity": "sha512-p8AnA4QE2GtrvkdmqnKrEiijtVlqdTIDCHZOwItkI9kW51bt5XnQ/4Anz8giiWf9kqBpEQwsmnChDCAFBRyR/Q==",
-      "dev": true,
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -35292,8 +35289,7 @@
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cooking-with-amateurs",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Portfolio Web App about Cooking Recipes",
   "main": "src/index.js",
   "scripts": {
@@ -54,7 +54,6 @@
     "nodemon": "^2.0.13",
     "prettier": "^1.19.1",
     "pretty-quick": "^2.0.1",
-    "react-hot-loader": "^4.12.19",
     "typescript": "^3.8.3",
     "webpack-dev-server": "^4.3.1"
   },
@@ -72,6 +71,7 @@
     "mongoose": "^5.9.7",
     "react": "^16.13.1",
     "react-dom": "^16.8.0",
+    "react-hot-loader": "^4.12.19",
     "react-router-dom": "^5.1.2",
     "ts-loader": "^7.0.2",
     "webpack": "^5.56.1",


### PR DESCRIPTION
…as it's referenced in code that runs in all envs, including prod

- [x] Unit tests: `npm run utest-cover` and check coverage
- [x] Functional tests: `npm run ftest` (make sure backend server is down)
- [x] While functional tests coverage is incomplete, manually test main pages
- [x] No errors or warnings in browser console
- [x] Upgrade version
- [x] Update to last version of chemistry-ui
